### PR TITLE
feat: add AgentIdentityRegistry and AgentReputationRegistry smart con…

### DIFF
--- a/antiphon/contracts/rachax402/.gitignore
+++ b/antiphon/contracts/rachax402/.gitignore
@@ -1,0 +1,17 @@
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Docs
+docs/
+
+# Dotenv file
+.env
+
+# Dependencies
+lib/

--- a/antiphon/contracts/rachax402/.gitmodules
+++ b/antiphon/contracts/rachax402/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/antiphon/contracts/rachax402/README.md
+++ b/antiphon/contracts/rachax402/README.md
@@ -1,0 +1,39 @@
+# Getting Started
+
+
+## File and Folder structure
+
+`/src/AgentIdentityRegistry.sol` - contract that allows agents to register with their agent card CIDs, tags and enables discovery by capability tags
+
+`/src/AgentReputationRegistry.sol` - contract for storing ratings and calculating reputation scores for agents with rate limiting
+
+`/test/AgentIdentityRegistry.t.sol` - tests for AgentIdentityRegistry contract
+
+`/test/AgentReputationRegistry.t.sol` - tests for AgentReputationRegistry contract
+
+
+
+## Build and Testing
+
+- To install necessary libraries and build the contracts, run:
+```bash
+cd antiphon/contracts/rachax402
+forge install
+forge build
+```
+
+- To test the contracts, run:
+```bash
+cd antiphon/contracts/rachax402
+# for AgentIdentityRegistry contract
+forge test --match-contract AgentIdentityRegistryTest -vvv
+
+# for AgentReputationRegistry contract
+forge test --match-contract AgentReputationRegistryTest -vvv
+```
+
+- To check the coverage report, run:
+```bash
+cd antiphon/contracts/rachax402
+forge coverage
+```

--- a/antiphon/contracts/rachax402/foundry.lock
+++ b/antiphon/contracts/rachax402/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.14.0",
+      "rev": "1801b0541f4fda118a10798fd3486bb7051c5dd6"
+    }
+  }
+}

--- a/antiphon/contracts/rachax402/foundry.toml
+++ b/antiphon/contracts/rachax402/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/antiphon/contracts/rachax402/src/AgentIdentityRegistry.sol
+++ b/antiphon/contracts/rachax402/src/AgentIdentityRegistry.sol
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/**
+ * @title AgentIdentityRegistry Contract
+ * @author Rachax402
+ * @dev Allows agents to register with their agent card CIDs and enables discovery by capability tags
+ */
+contract AgentIdentityRegistry {
+    // Errors
+    error AgentAlreadyRegistered(address agent);
+    error AgentNotRegistered(address agent);
+    error NotAgentOwner(address caller, address agent);
+    error InvalidCID();
+    error InvalidCapabilityTag();
+    error EmptyCapabilityTags();
+
+    // Type Declarations
+    struct AgentInfo {
+        string agentCardCID;
+        string[] capabilityTags;
+        bool isRegistered;
+    }
+
+    // State Variables
+    /// @dev Mapping from agent address to their info
+    mapping(address => AgentInfo) private s_agents;
+
+    /// @dev Mapping from capability tag to list of agent addresses for efficient lookup
+    mapping(string => address[]) private s_capabilityToAgents;
+
+    /// @dev Mapping to track agent index in capability array for O(1) removal
+    mapping(string => mapping(address => uint256)) private s_agentIndexInCapability;
+
+    /// @dev Mapping to track if agent has a specific capability (for O(1) lookup)
+    mapping(address => mapping(string => bool)) private s_agentHasCapability;
+
+    /// @dev Array of all registered agent addresses
+    address[] private s_registeredAgents;
+
+    /// @dev Mapping to track agent index in registered agents array
+    mapping(address => uint256) private s_agentIndexInRegistry;
+
+    // Events
+    event AgentRegistered(
+        address indexed agent,
+        string agentCardCID,
+        string[] capabilityTags
+    );
+    event AgentCardUpdated(
+        address indexed agent,
+        string oldAgentCardCID,
+        string newAgentCardCID,
+        string[] newCapabilityTags
+    );
+    event CapabilityAdded(address indexed agent, string capability);
+    event CapabilityRemoved(address indexed agent, string capability);
+
+    // Modifiers
+    modifier onlyAgentOwner() {
+        if (!s_agents[msg.sender].isRegistered) {
+            revert AgentNotRegistered(msg.sender);
+        }
+        _;
+    }
+
+    modifier validCID(string memory cid) {
+        if (bytes(cid).length == 0) {
+            revert InvalidCID();
+        }
+        _;
+    }
+
+    // Constructor
+    constructor() {}
+
+    // External Functions
+
+    /**
+     * @dev registerAgent Register an agent with their agent card CID and capability tags
+     * @param agentCardCID The CID of the agent's identity card stored on IPFS
+     * @param capabilityTags An array of capability tags for the agent
+     */
+    function registerAgent(
+        string calldata agentCardCID,
+        string[] calldata capabilityTags
+    ) external validCID(agentCardCID) {
+        if (s_agents[msg.sender].isRegistered) {
+            revert AgentAlreadyRegistered(msg.sender);
+        }
+
+        // Store agent info
+        s_agents[msg.sender].agentCardCID = agentCardCID;
+        s_agents[msg.sender].isRegistered = true;
+
+        // Add to registered agents array
+        s_agentIndexInRegistry[msg.sender] = s_registeredAgents.length;
+        s_registeredAgents.push(msg.sender);
+
+        // index capability tags
+        _addCapabilities(msg.sender, capabilityTags);
+
+        emit AgentRegistered(msg.sender, agentCardCID, capabilityTags);
+    }
+
+    /**
+     * @dev updateAgentCard update the agent identity card CID and capability tags
+     * @notice Only the agent owner can update their agent card
+     * @param newCID The new CID of the agent's identity card stored on IPFS
+     * @param newCapabilityTags The new capability tags for the agent
+     */
+    function updateAgentCard(
+        string calldata newCID,
+        string[] calldata newCapabilityTags
+    ) external onlyAgentOwner() validCID(newCID) {
+        string memory oldCID = s_agents[msg.sender].agentCardCID;
+
+        // Remove old capabilities
+        _removeAllCapabilities(msg.sender);
+
+        // Update CID
+        s_agents[msg.sender].agentCardCID = newCID;
+
+        // Add new capabilities
+        _addCapabilities(msg.sender, newCapabilityTags);
+
+        emit AgentCardUpdated(msg.sender, oldCID, newCID, newCapabilityTags);
+    }
+
+    /**
+     * @dev discoverAgents discover agents by capability tags (returns agents matching ANY of the provided tags)
+     * @param capabilityTags An array of capability tags to search for agents
+     * @notice this take O(n^3) complexity in worst case due to uniqueness check..... Not efficient!!!!
+
+     * @return agents An array of unique agent addresses matching the capability tags
+     * @return cids An array of corresponding agent card CIDs
+     */
+    function discoverAgents(
+        string[] calldata capabilityTags
+    ) external view returns (address[] memory agents, string[] memory cids) {
+        if (capabilityTags.length == 0) {
+            revert EmptyCapabilityTags();
+        }
+
+        // First pass: count unique agents
+        uint256 maxAgents = 0;
+        for (uint256 i = 0; i < capabilityTags.length; i++) {
+            maxAgents += s_capabilityToAgents[capabilityTags[i]].length;
+        }
+
+        if (maxAgents == 0) {
+            return (new address[](0), new string[](0));
+        }
+
+        // Temporary arrays for collecting unique agents
+        address[] memory tempAgents = new address[](maxAgents);
+        uint256 uniqueCount = 0;
+
+        // Track which agents we've already added (using a simple loop for uniqueness)
+        for (uint256 i = 0; i < capabilityTags.length; i++) {
+            address[] storage agentsWithCapability = s_capabilityToAgents[capabilityTags[i]];
+
+            for (uint256 j = 0; j < agentsWithCapability.length; j++) {
+                address agent = agentsWithCapability[j];
+
+                // Check if agent is already in our result
+                bool alreadyAdded = false;
+                for (uint256 k = 0; k < uniqueCount; k++) {
+                    if (tempAgents[k] == agent) {
+                        alreadyAdded = true;
+                        break;
+                    }
+                }
+
+                if (!alreadyAdded) {
+                    tempAgents[uniqueCount] = agent;
+                    uniqueCount++;
+                }
+            }
+        }
+
+        // Create correctly sized result arrays
+        agents = new address[](uniqueCount);
+        cids = new string[](uniqueCount);
+
+        for (uint256 i = 0; i < uniqueCount; i++) {
+            agents[i] = tempAgents[i];
+            cids[i] = s_agents[tempAgents[i]].agentCardCID;
+        }
+
+        return (agents, cids);
+    }
+
+    // External Getter Functions
+
+    /**
+     * @dev getAgentCard Get the agent card CID for a given agent address
+     * @param agent The address of the agent
+     * @return The CID of the agent's identity card stored on IPFS
+     */
+    function getAgentCard(
+        address agent
+    ) external view returns (string memory) {
+        if (!s_agents[agent].isRegistered) {
+            revert AgentNotRegistered(agent);
+        }
+        return s_agents[agent].agentCardCID;
+    }
+
+    /**
+     * @dev Get the capability tags for a given agent address
+     * @param agent The address of the agent
+     * @return The capability tags of the agent
+     */
+    function getAgentCapabilities(
+        address agent
+    ) external view returns (string[] memory) {
+        if (!s_agents[agent].isRegistered) {
+            revert AgentNotRegistered(agent);
+        }
+        return s_agents[agent].capabilityTags;
+    }
+
+    /**
+     * @dev Check if an agent is registered
+     * @param agent The address of the agent
+     * @return True if the agent is registered, false otherwise
+     */
+    function isAgentRegistered(address agent) external view returns (bool) {
+        return s_agents[agent].isRegistered;
+    }
+
+    /**
+     * @dev Get all agents with a specific capability
+     * @param capability The capability tag to search for
+     * @return An array of agent addresses with the specified capability
+     */
+    function getAgentsByCapability(
+        string calldata capability
+    ) external view returns (address[] memory) {
+        return s_capabilityToAgents[capability];
+    }
+
+    /**
+     * @dev Get the total number of registered agents
+     * @return The count of registered agents
+     */
+    function getRegisteredAgentsCount() external view returns (uint256) {
+        return s_registeredAgents.length;
+    }
+
+    /**
+     * @dev Get all registered agent addresses
+     * @return An array of all registered agent addresses
+     */
+    function getAllRegisteredAgents() external view returns (address[] memory) {
+        return s_registeredAgents;
+    }
+
+    /**
+     * @dev Check if an agent has a specific capability
+     * @param agent The address of the agent
+     * @param capability The capability tag to check
+     * @return True if the agent has the capability, false otherwise
+     */
+    function agentHasCapability(
+        address agent,
+        string calldata capability
+    ) external view returns (bool) {
+        return s_agentHasCapability[agent][capability];
+    }
+
+    // Internal Functions
+
+    /**
+     * @dev Add capability tags to an agent and update the capability index
+     * @param agent The address of the agent
+     * @param capabilities The capability tags to add
+     */
+    function _addCapabilities(
+        address agent,
+        string[] calldata capabilities
+    ) internal {
+        for (uint256 i = 0; i < capabilities.length; i++) {
+            string calldata capability = capabilities[i];
+
+            // skip the empty capabilities
+            if (bytes(capability).length == 0) {
+                continue;
+            }
+
+            // skip if agent already have the capability
+            if (s_agentHasCapability[agent][capability]) {
+                continue;
+            }
+
+            // Add to agent's capabilities
+            s_agents[agent].capabilityTags.push(capability);
+
+            // index for efficient lookup
+            s_agentIndexInCapability[capability][agent] = s_capabilityToAgents[capability].length;
+            s_capabilityToAgents[capability].push(agent);
+            s_agentHasCapability[agent][capability] = true;
+
+            emit CapabilityAdded(agent, capability);
+        }
+    }
+
+    /**
+     * @dev Remove all capability tags from an agent
+     * @param agent The address of the agent
+     */
+    function _removeAllCapabilities(address agent) internal {
+        string[] storage capabilities = s_agents[agent].capabilityTags;
+
+        for (uint256 i = 0; i < capabilities.length; i++) {
+            string storage capability = capabilities[i];
+
+            // Remove from capability index using swap-and-pop
+            uint256 indexToRemove = s_agentIndexInCapability[capability][agent];
+            uint256 lastIndex = s_capabilityToAgents[capability].length - 1;
+
+            if (indexToRemove != lastIndex) {
+                address lastAgent = s_capabilityToAgents[capability][lastIndex];
+                s_capabilityToAgents[capability][indexToRemove] = lastAgent;
+                s_agentIndexInCapability[capability][lastAgent] = indexToRemove;
+            }
+
+            s_capabilityToAgents[capability].pop();
+            delete s_agentIndexInCapability[capability][agent];
+            s_agentHasCapability[agent][capability] = false;
+
+            emit CapabilityRemoved(agent, capability);
+        }
+
+        // Clear agent's capabilities array
+        delete s_agents[agent].capabilityTags;
+    }
+}

--- a/antiphon/contracts/rachax402/src/AgentReputationRegistry.sol
+++ b/antiphon/contracts/rachax402/src/AgentReputationRegistry.sol
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/**
+ * @title AgentReputationRegistry Contract
+ * @author Rachax402
+ * @dev Contract for storing ratings and calculating reputation scores for agents
+ */
+contract AgentReputationRegistry {
+    // Errors
+    error InvalidRating(uint8 rating);
+    error InvalidTargetAgent();
+    error CannotRateSelf();
+    error RateLimitExceeded(address rater, address targetAgent, uint256 nextAllowedTime);
+    error NoRatingsFound(address agent);
+    error InvalidLimit();
+
+    // Type Declarations
+    struct Rating {
+        uint8 rating;
+        string comment;
+        string proofCID;
+        uint256 timestamp;
+        address rater;
+    }
+
+    struct AgentReputation {
+        uint256 totalScore;      // Sum of all ratings (scaled by 100)
+        uint256 totalRatings;    // Number of ratings received
+        uint256 ratingsCount;    // Total ratings in the array
+    }
+
+    // Constants
+    uint8 public constant MIN_RATING = 1;
+    uint8 public constant MAX_RATING = 5;
+    uint256 public constant SCORE_MULTIPLIER = 100;
+    uint256 public constant RATE_LIMIT_PERIOD = 1 days;
+
+    // State Variables
+    /// @dev Mapping from agent address to their reputation data
+    mapping(address => AgentReputation) private s_agentReputations;
+
+    /// @dev Mapping from agent address to their ratings array
+    mapping(address => Rating[]) private s_agentRatings;
+
+    /// @dev Mapping to track last rating timestamp: rater => targetAgent => timestamp
+    mapping(address => mapping(address => uint256)) private s_lastRatingTime;
+
+    /// @dev Array of all agents that have received ratings
+    address[] private s_ratedAgents;
+
+    /// @dev Mapping to check if agent has been rated before
+    mapping(address => bool) private s_hasBeenRated;
+
+    // Events
+    event ReputationPosted(
+        address indexed targetAgent,
+        address indexed rater,
+        uint8 rating,
+        string comment,
+        string proofCID,
+        uint256 timestamp
+    );
+
+    event FirstRatingReceived(address indexed agent);
+
+    // Modifiers
+    modifier validRating(uint8 rating) {
+        if (rating < MIN_RATING || rating > MAX_RATING) {
+            revert InvalidRating(rating);
+        }
+        _;
+    }
+
+    modifier validTarget(address targetAgent) {
+        if (targetAgent == address(0)) {
+            revert InvalidTargetAgent();
+        }
+        if (targetAgent == msg.sender) {
+            revert CannotRateSelf();
+        }
+        _;
+    }
+
+    modifier rateLimitCheck(address targetAgent) {
+        uint256 lastRating = s_lastRatingTime[msg.sender][targetAgent];
+        if (lastRating != 0 && block.timestamp < lastRating + RATE_LIMIT_PERIOD) {
+            revert RateLimitExceeded(
+                msg.sender,
+                targetAgent,
+                lastRating + RATE_LIMIT_PERIOD
+            );
+        }
+        _;
+    }
+
+    // Constructor
+    constructor() {}
+
+    // External Functions
+
+    /**
+     * @dev postReputation Post a reputation rating for an agent
+     * @param targetAgent The address of the agent being rated
+     * @param rating The rating value (1-5)
+     * @param comment comment about the rating
+     * @param proofCID CID of proof/evidence stored on IPFS
+     */
+    function postReputation(
+        address targetAgent,
+        uint8 rating,
+        string calldata comment,
+        string calldata proofCID
+    )
+        external
+        validTarget(targetAgent)
+        validRating(rating)
+        rateLimitCheck(targetAgent)
+    {
+        // Update rate limit timestamp
+        s_lastRatingTime[msg.sender][targetAgent] = block.timestamp;
+
+        // Create new rating
+        Rating memory newRating = Rating({
+            rating: rating,
+            comment: comment,
+            proofCID: proofCID,
+            timestamp: block.timestamp,
+            rater: msg.sender
+        });
+
+        // Store the rating
+        s_agentRatings[targetAgent].push(newRating);
+
+        // Update reputation scores (rating * 100 for precision)
+        s_agentReputations[targetAgent].totalScore += uint256(rating) * SCORE_MULTIPLIER;
+        s_agentReputations[targetAgent].totalRatings += 1;
+        s_agentReputations[targetAgent].ratingsCount += 1;
+
+        // Optional: Track first-time rated agents
+        if (!s_hasBeenRated[targetAgent]) {
+            s_hasBeenRated[targetAgent] = true;
+            s_ratedAgents.push(targetAgent);
+            emit FirstRatingReceived(targetAgent);
+        }
+
+        emit ReputationPosted(
+            targetAgent,
+            msg.sender,
+            rating,
+            comment,
+            proofCID,
+            block.timestamp
+        );
+    }
+
+    // External View Functions
+
+    /**
+     * @dev getReputationScore Get the reputation score for an agent
+     * @param agent The address of the agent
+     * @return score ( average reputation score * 100)
+     * @return totalRatings The total number of ratings received
+     * @notice Score of 500 = 5.00 average, 350 = 3.50 average, etc.
+     */
+    function getReputationScore(
+        address agent
+    ) external view returns (uint256 score, uint256 totalRatings) {
+        AgentReputation storage rep = s_agentReputations[agent];
+        totalRatings = rep.totalRatings;
+
+        if (totalRatings == 0) {
+            return (0, 0);
+        }
+
+        // Calculate average: (totalScore / totalRatings)
+        // Since totalScore is already multiplied by 100, result is average * 100
+        score = rep.totalScore / totalRatings;
+
+        return (score, totalRatings);
+    }
+
+    /**
+     * @dev Get recent ratings for an agent
+     * @param agent The address of the agent
+     * @param limit Maximum number of ratings to return (most recent first)
+     * @return An array of Rating structs
+     */
+    function getRecentRatings(
+        address agent,
+        uint256 limit
+    ) external view returns (Rating[] memory) {
+        if (limit == 0) {
+            revert InvalidLimit();
+        }
+
+        Rating[] storage allRatings = s_agentRatings[agent];
+        uint256 totalRatings = allRatings.length;
+
+        if (totalRatings == 0) {
+            return new Rating[](0);
+        }
+
+        // Determine how many ratings to return
+        uint256 count = limit > totalRatings ? totalRatings : limit;
+        Rating[] memory recentRatings = new Rating[](count);
+
+        // Return most recent ratings first (reverse order)
+        for (uint256 i = 0; i < count; i++) {
+            recentRatings[i] = allRatings[totalRatings - 1 - i];
+        }
+
+        return recentRatings;
+    }
+
+    /**
+     * @dev Get all ratings for an agent
+     * @param agent The address of the agent
+     * @return An array of all Rating structs
+     */
+    function getAllRatings(
+        address agent
+    ) external view returns (Rating[] memory) {
+        return s_agentRatings[agent];
+    }
+
+    /**
+     * @dev Get the total number of ratings for an agent
+     * @param agent The address of the agent
+     * @return The count of ratings
+     */
+    function getRatingsCount(address agent) external view returns (uint256) {
+        return s_agentRatings[agent].length;
+    }
+
+    /**
+     * @dev Check if a rater can rate a target agent (rate limit check)
+     * @param rater The address of the potential rater
+     * @param targetAgent The address of the target agent
+     * @return canRate Whether the rater can rate now
+     * @return nextAllowedTime The timestamp when rating will be allowed (0 if can rate now)
+     */
+    function canRate(
+        address rater,
+        address targetAgent
+    ) external view returns (bool, uint256 nextAllowedTime) {
+        uint256 lastRating = s_lastRatingTime[rater][targetAgent];
+
+        if (lastRating == 0) {
+            return (true, 0);
+        }
+
+        nextAllowedTime = lastRating + RATE_LIMIT_PERIOD;
+
+        if (block.timestamp >= nextAllowedTime) {
+            return (true, 0);
+        }
+
+        return (false, nextAllowedTime);
+    }
+
+
+    /**
+     * @dev Check if an agent has received any ratings
+     * @param agent The address of the agent
+     * @return True if the agent has been rated
+     */
+    function hasBeenRated(address agent) external view returns (bool) {
+        return s_hasBeenRated[agent];
+    }
+
+}

--- a/antiphon/contracts/rachax402/test/AgentIdentityRegistry.t.sol
+++ b/antiphon/contracts/rachax402/test/AgentIdentityRegistry.t.sol
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Vm} from "lib/forge-std/src/Vm.sol";
+import {AgentIdentityRegistry} from "../src/AgentIdentityRegistry.sol";
+
+contract AgentIdentityRegistryTest is Test {
+    AgentIdentityRegistry public registry;
+
+    // Test addresses
+    address public agentA;
+    address public agentB;
+    address public agentC;
+
+    // Test CIDs
+    string public constant CID_A = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+    string public constant CID_B = "bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy";
+    string public constant CID_C = "bafybeihkoviema7g3gxyt6la7vd5ho32ictqbilu3ez5n5zvkdxjqpnqfa";
+    string public constant UPDATED_CID = "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq";
+
+    // Test capability tags
+    string[] public capabilitiesA;
+    string[] public capabilitiesB;
+    string[] public capabilitiesC;
+    string[] public updatedCapabilities;
+    string[] public emptyCapabilities;
+
+    // Events to test
+    event AgentRegistered(
+        address indexed agent,
+        string agentCardCID,
+        string[] capabilityTags
+    );
+    event AgentCardUpdated(
+        address indexed agent,
+        string oldAgentCardCID,
+        string newAgentCardCID,
+        string[] newCapabilityTags
+    );
+    event CapabilityAdded(address indexed agent, string capability);
+    event CapabilityRemoved(address indexed agent, string capability);
+
+    function setUp() public {
+        registry = new AgentIdentityRegistry();
+
+        // Setup test addresses
+        agentA = makeAddr("agentA");
+        agentB = makeAddr("agentB");
+        agentC = makeAddr("agentC");
+
+        // Setup capability arrays
+        capabilitiesA = new string[](2);
+        capabilitiesA[0] = "csv-analysis";
+        capabilitiesA[1] = "statistics";
+
+        capabilitiesB = new string[](2);
+        capabilitiesB[0] = "statistics";
+        capabilitiesB[1] = "data-transformation";
+
+        capabilitiesC = new string[](1);
+        capabilitiesC[0] = "json-processing";
+
+        updatedCapabilities = new string[](2);
+        updatedCapabilities[0] = "machine-learning";
+        updatedCapabilities[1] = "prediction";
+
+        emptyCapabilities = new string[](0);
+    }
+
+    // registerAgent Tests
+
+    function test_RegisterAgent_Success() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        assertTrue(registry.isAgentRegistered(agentA));
+        assertEq(registry.getAgentCard(agentA), CID_A);
+        assertEq(registry.getRegisteredAgentsCount(), 1);
+    }
+
+    function test_RegisterAgent_EmitsEvent() public {
+        vm.expectEmit(true, false, false, true);
+        emit AgentRegistered(agentA, CID_A, capabilitiesA);
+
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+    }
+
+    function test_RegisterAgent_EmitsCapabilityAddedEvents() public {
+        vm.expectEmit(true, false, false, true);
+        emit CapabilityAdded(agentA, "csv-analysis");
+
+        vm.expectEmit(true, false, false, true);
+        emit CapabilityAdded(agentA, "statistics");
+
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+    }
+
+    function test_RegisterAgent_WithEmptyCapabilities() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, emptyCapabilities);
+
+        assertTrue(registry.isAgentRegistered(agentA));
+        assertEq(registry.getAgentCapabilities(agentA).length, 0);
+    }
+
+    function test_RegisterAgent_RevertIfAlreadyRegistered() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentIdentityRegistry.AgentAlreadyRegistered.selector,
+                agentA
+            )
+        );
+
+        vm.prank(agentA);
+        registry.registerAgent(CID_B, capabilitiesB);
+    }
+
+    function test_RegisterAgent_RevertIfEmptyCID() public {
+        vm.expectRevert(AgentIdentityRegistry.InvalidCID.selector);
+
+        vm.prank(agentA);
+        registry.registerAgent("", capabilitiesA);
+    }
+
+    function test_RegisterAgent_MultipleAgents() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        vm.prank(agentB);
+        registry.registerAgent(CID_B, capabilitiesB);
+
+        vm.prank(agentC);
+        registry.registerAgent(CID_C, capabilitiesC);
+
+        assertEq(registry.getRegisteredAgentsCount(), 3);
+
+        address[] memory allAgents = registry.getAllRegisteredAgents();
+        assertEq(allAgents.length, 3);
+        assertEq(allAgents[0], agentA);
+        assertEq(allAgents[1], agentB);
+        assertEq(allAgents[2], agentC);
+    }
+
+    // updateAgentCard Tests
+
+    function test_UpdateAgentCard_Success() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        vm.prank(agentA);
+        registry.updateAgentCard(UPDATED_CID, updatedCapabilities);
+
+        assertEq(registry.getAgentCard(agentA), UPDATED_CID);
+
+        string[] memory newCaps = registry.getAgentCapabilities(agentA);
+        assertEq(newCaps.length, 2);
+        assertEq(newCaps[0], "machine-learning");
+        assertEq(newCaps[1], "prediction");
+    }
+
+    function test_UpdateAgentCard_EmitsEvent() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        vm.expectEmit(true, false, false, true);
+        emit AgentCardUpdated(agentA, CID_A, UPDATED_CID, updatedCapabilities);
+
+        vm.prank(agentA);
+        registry.updateAgentCard(UPDATED_CID, updatedCapabilities);
+    }
+
+    function test_UpdateAgentCard_RemovesOldCapabilities() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        assertTrue(registry.agentHasCapability(agentA, "csv-analysis"));
+        assertTrue(registry.agentHasCapability(agentA, "statistics"));
+
+        vm.prank(agentA);
+        registry.updateAgentCard(UPDATED_CID, updatedCapabilities);
+
+        assertFalse(registry.agentHasCapability(agentA, "csv-analysis"));
+        assertFalse(registry.agentHasCapability(agentA, "statistics"));
+        assertTrue(registry.agentHasCapability(agentA, "machine-learning"));
+        assertTrue(registry.agentHasCapability(agentA, "prediction"));
+    }
+
+    function test_UpdateAgentCard_RevertIfNotRegistered() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentIdentityRegistry.AgentNotRegistered.selector,
+                agentA
+            )
+        );
+
+        vm.prank(agentA);
+        registry.updateAgentCard(UPDATED_CID, updatedCapabilities);
+    }
+
+    function test_UpdateAgentCard_RevertIfEmptyCID() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        vm.expectRevert(AgentIdentityRegistry.InvalidCID.selector);
+
+        vm.prank(agentA);
+        registry.updateAgentCard("", updatedCapabilities);
+    }
+
+    // discoverAgents Tests
+
+    function test_DiscoverAgents_SingleCapability() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        vm.prank(agentB);
+        registry.registerAgent(CID_B, capabilitiesB);
+
+        string[] memory searchTags = new string[](1);
+        searchTags[0] = "statistics";
+
+        (address[] memory agents, string[] memory cids) = registry.discoverAgents(searchTags);
+
+        assertEq(agents.length, 2);
+        assertEq(cids.length, 2);
+    }
+
+    function test_DiscoverAgents_MultipleCapabilities() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        vm.prank(agentB);
+        registry.registerAgent(CID_B, capabilitiesB);
+
+        vm.prank(agentC);
+        registry.registerAgent(CID_C, capabilitiesC);
+
+        string[] memory searchTags = new string[](2);
+        searchTags[0] = "csv-analysis";
+        searchTags[1] = "json-processing";
+
+        (address[] memory agents, string[] memory cids) = registry.discoverAgents(searchTags);
+
+        assertEq(agents.length, 2);
+        // Should contain agentA (csv-analysis) and agentC (json-processing)
+    }
+
+    function test_DiscoverAgents_NoDuplicates() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        // Search for both capabilities that agentA has
+        string[] memory searchTags = new string[](2);
+        searchTags[0] = "csv-analysis";
+        searchTags[1] = "statistics";
+
+        (address[] memory agents, string[] memory cids) = registry.discoverAgents(searchTags);
+
+        // Should only return agentA once (no duplicates)
+        assertEq(agents.length, 1);
+        assertEq(agents[0], agentA);
+        assertEq(cids[0], CID_A);
+    }
+
+    function test_DiscoverAgents_NoMatches() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        string[] memory searchTags = new string[](1);
+        searchTags[0] = "non-existent-capability";
+
+        (address[] memory agents, string[] memory cids) = registry.discoverAgents(searchTags);
+
+        assertEq(agents.length, 0);
+        assertEq(cids.length, 0);
+    }
+
+    function test_DiscoverAgents_RevertIfEmptyTags() public {
+        vm.expectRevert(AgentIdentityRegistry.EmptyCapabilityTags.selector);
+
+        registry.discoverAgents(emptyCapabilities);
+    }
+
+    // getAgentCard Tests
+
+    function test_GetAgentCard_Success() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        string memory cid = registry.getAgentCard(agentA);
+        assertEq(cid, CID_A);
+    }
+
+    function test_GetAgentCard_RevertIfNotRegistered() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentIdentityRegistry.AgentNotRegistered.selector,
+                agentA
+            )
+        );
+
+        registry.getAgentCard(agentA);
+    }
+
+    // getAgentCapabilities Tests
+
+    function test_GetAgentCapabilities_Success() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        string[] memory caps = registry.getAgentCapabilities(agentA);
+
+        assertEq(caps.length, 2);
+        assertEq(caps[0], "csv-analysis");
+        assertEq(caps[1], "statistics");
+    }
+
+    function test_GetAgentCapabilities_RevertIfNotRegistered() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentIdentityRegistry.AgentNotRegistered.selector,
+                agentA
+            )
+        );
+
+        registry.getAgentCapabilities(agentA);
+    }
+
+    // getAgentsByCapability Tests
+
+    function test_GetAgentsByCapability_Success() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        vm.prank(agentB);
+        registry.registerAgent(CID_B, capabilitiesB);
+
+        address[] memory statisticsAgents = registry.getAgentsByCapability("statistics");
+
+        assertEq(statisticsAgents.length, 2);
+        assertEq(statisticsAgents[0], agentA);
+        assertEq(statisticsAgents[1], agentB);
+    }
+
+    function test_GetAgentsByCapability_EmptyResult() public {
+        address[] memory agents = registry.getAgentsByCapability("non-existent");
+        assertEq(agents.length, 0);
+    }
+
+    // agentHasCapability Tests
+
+    function test_AgentHasCapability_True() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        assertTrue(registry.agentHasCapability(agentA, "csv-analysis"));
+        assertTrue(registry.agentHasCapability(agentA, "statistics"));
+    }
+
+    function test_AgentHasCapability_False() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        assertFalse(registry.agentHasCapability(agentA, "non-existent"));
+        assertFalse(registry.agentHasCapability(agentB, "csv-analysis"));
+    }
+
+    // isAgentRegistered Tests
+
+    function test_IsAgentRegistered_True() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        assertTrue(registry.isAgentRegistered(agentA));
+    }
+
+    function test_IsAgentRegistered_False() public {
+        assertFalse(registry.isAgentRegistered(agentA));
+    }
+
+    // Capability Indexing Tests
+
+    function test_CapabilityIndexing_AfterUpdate() public {
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capabilitiesA);
+
+        // Initially agentA has "statistics"
+        address[] memory beforeUpdate = registry.getAgentsByCapability("statistics");
+        assertEq(beforeUpdate.length, 1);
+
+        // Update to remove "statistics"
+        vm.prank(agentA);
+        registry.updateAgentCard(UPDATED_CID, updatedCapabilities);
+
+        // Now "statistics" should have no agents
+        address[] memory afterUpdate = registry.getAgentsByCapability("statistics");
+        assertEq(afterUpdate.length, 0);
+
+        // New capabilities should be indexed
+        address[] memory mlAgents = registry.getAgentsByCapability("machine-learning");
+        assertEq(mlAgents.length, 1);
+        assertEq(mlAgents[0], agentA);
+    }
+
+    function test_CapabilityIndexing_SkipsDuplicates() public {
+        // Create capabilities with duplicates
+        string[] memory capsWithDupes = new string[](3);
+        capsWithDupes[0] = "csv-analysis";
+        capsWithDupes[1] = "csv-analysis"; // duplicate
+        capsWithDupes[2] = "statistics";
+
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capsWithDupes);
+
+        // Should only have 2 unique capabilities
+        string[] memory caps = registry.getAgentCapabilities(agentA);
+        assertEq(caps.length, 2);
+
+        // Capability index should only have agentA once
+        address[] memory csvAgents = registry.getAgentsByCapability("csv-analysis");
+        assertEq(csvAgents.length, 1);
+    }
+
+    function test_CapabilityIndexing_SkipsEmpty() public {
+        string[] memory capsWithEmpty = new string[](3);
+        capsWithEmpty[0] = "csv-analysis";
+        capsWithEmpty[1] = ""; // empty
+        capsWithEmpty[2] = "statistics";
+
+        vm.prank(agentA);
+        registry.registerAgent(CID_A, capsWithEmpty);
+
+        // Should only have 2 capabilities (empty skipped)
+        string[] memory caps = registry.getAgentCapabilities(agentA);
+        assertEq(caps.length, 2);
+    }
+}

--- a/antiphon/contracts/rachax402/test/AgentReputationRegistry.t.sol
+++ b/antiphon/contracts/rachax402/test/AgentReputationRegistry.t.sol
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Vm} from "lib/forge-std/src/Vm.sol";
+import {AgentReputationRegistry} from "../src/AgentReputationRegistry.sol";
+
+contract AgentReputationRegistryTest is Test {
+    AgentReputationRegistry public registry;
+
+    // Test addresses
+    address public raterA;
+    address public raterB;
+    address public raterC;
+    address public targetAgent;
+    address public anotherAgent;
+
+    // Test constants
+    string public constant COMMENT_GOOD = "Excellent service, fast processing";
+    string public constant COMMENT_BAD = "Slow response time";
+    string public constant PROOF_CID = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+    string public constant EMPTY_STRING = "";
+
+    // Events to test
+    event ReputationPosted(
+        address indexed targetAgent,
+        address indexed rater,
+        uint8 rating,
+        string comment,
+        string proofCID,
+        uint256 timestamp
+    );
+    event FirstRatingReceived(address indexed agent);
+
+    function setUp() public {
+        registry = new AgentReputationRegistry();
+
+        // Setup test addresses
+        raterA = makeAddr("raterA");
+        raterB = makeAddr("raterB");
+        raterC = makeAddr("raterC");
+        targetAgent = makeAddr("targetAgent");
+        anotherAgent = makeAddr("anotherAgent");
+    }
+
+    // postReputation Tests
+
+    function test_PostReputation_Success() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        assertTrue(registry.hasBeenRated(targetAgent));
+        assertEq(registry.getRatingsCount(targetAgent), 1);
+    }
+
+    function test_PostReputation_EmitsReputationPostedEvent() public {
+        vm.expectEmit(true, true, false, true);
+        emit ReputationPosted(targetAgent, raterA, 5, COMMENT_GOOD, PROOF_CID, block.timestamp);
+
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+    }
+
+    function test_PostReputation_EmitsFirstRatingReceivedEvent() public {
+        vm.expectEmit(true, false, false, false);
+        emit FirstRatingReceived(targetAgent);
+
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+    }
+
+    function test_PostReputation_NoFirstRatingEventOnSecondRating() public {
+        // First rating
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        // Second rating from different rater - should NOT emit FirstRatingReceived
+        vm.recordLogs();
+        vm.prank(raterB);
+        registry.postReputation(targetAgent, 4, COMMENT_GOOD, PROOF_CID);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        // Should only have ReputationPosted event, not FirstRatingReceived
+        bool hasFirstRatingEvent = false;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == keccak256("FirstRatingReceived(address)")) {
+                hasFirstRatingEvent = true;
+            }
+        }
+        assertFalse(hasFirstRatingEvent);
+    }
+
+    function test_PostReputation_WithEmptyComment() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, EMPTY_STRING, PROOF_CID);
+
+        assertEq(registry.getRatingsCount(targetAgent), 1);
+    }
+
+    function test_PostReputation_WithEmptyProofCID() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, EMPTY_STRING);
+
+        assertEq(registry.getRatingsCount(targetAgent), 1);
+    }
+
+    function test_PostReputation_MultipleRaters() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        vm.prank(raterB);
+        registry.postReputation(targetAgent, 4, COMMENT_GOOD, PROOF_CID);
+
+        vm.prank(raterC);
+        registry.postReputation(targetAgent, 3, COMMENT_BAD, PROOF_CID);
+
+        assertEq(registry.getRatingsCount(targetAgent), 3);
+    }
+
+    function test_PostReputation_RevertIfZeroRating() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentReputationRegistry.InvalidRating.selector,
+                0
+            )
+        );
+
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 0, COMMENT_GOOD, PROOF_CID);
+    }
+
+    function test_PostReputation_RevertIfRatingTooHigh() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentReputationRegistry.InvalidRating.selector,
+                6
+            )
+        );
+
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 6, COMMENT_GOOD, PROOF_CID);
+    }
+
+    function test_PostReputation_RevertIfTargetIsZeroAddress() public {
+        vm.expectRevert(AgentReputationRegistry.InvalidTargetAgent.selector);
+
+        vm.prank(raterA);
+        registry.postReputation(address(0), 5, COMMENT_GOOD, PROOF_CID);
+    }
+
+    function test_PostReputation_RevertIfRatingSelf() public {
+        vm.expectRevert(AgentReputationRegistry.CannotRateSelf.selector);
+
+        vm.prank(raterA);
+        registry.postReputation(raterA, 5, COMMENT_GOOD, PROOF_CID);
+    }
+
+    function test_PostReputation_RevertIfRateLimitExceeded() public {
+        // First rating
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        // Try to rate again immediately
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentReputationRegistry.RateLimitExceeded.selector,
+                raterA,
+                targetAgent,
+                block.timestamp + 1 days
+            )
+        );
+
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 4, COMMENT_GOOD, PROOF_CID);
+    }
+
+    function test_PostReputation_SuccessAfterRateLimitPeriod() public {
+        // First rating
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        // Warp time forward past rate limit
+        vm.warp(block.timestamp + 1 days + 1);
+
+        // Should succeed now
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 4, COMMENT_GOOD, PROOF_CID);
+
+        assertEq(registry.getRatingsCount(targetAgent), 2);
+    }
+
+    function test_PostReputation_DifferentTargetsNoRateLimit() public {
+        // Rate first target
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        // Rate different target immediately - should succeed
+        vm.prank(raterA);
+        registry.postReputation(anotherAgent, 4, COMMENT_GOOD, PROOF_CID);
+
+        assertEq(registry.getRatingsCount(targetAgent), 1);
+        assertEq(registry.getRatingsCount(anotherAgent), 1);
+    }
+
+    // getReputationScore Tests
+
+    function test_GetReputationScore_SingleRating() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        (uint256 score, uint256 totalRatings) = registry.getReputationScore(targetAgent);
+
+        assertEq(score, 500); // 5 * 100
+        assertEq(totalRatings, 1);
+    }
+
+    function test_GetReputationScore_MultipleRatings() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        vm.prank(raterB);
+        registry.postReputation(targetAgent, 4, COMMENT_GOOD, PROOF_CID);
+
+        vm.prank(raterC);
+        registry.postReputation(targetAgent, 3, COMMENT_BAD, PROOF_CID);
+
+        (uint256 score, uint256 totalRatings) = registry.getReputationScore(targetAgent);
+
+        // Average: (5 + 4 + 3) / 3 = 4.0 => 400
+        assertEq(score, 400);
+        assertEq(totalRatings, 3);
+    }
+
+    function test_GetReputationScore_NoRatings() public {
+        (uint256 score, uint256 totalRatings) = registry.getReputationScore(targetAgent);
+
+        assertEq(score, 0);
+        assertEq(totalRatings, 0);
+    }
+
+    function test_GetReputationScore_AllMinRatings() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 1, COMMENT_BAD, PROOF_CID);
+
+        vm.prank(raterB);
+        registry.postReputation(targetAgent, 1, COMMENT_BAD, PROOF_CID);
+
+        (uint256 score, uint256 totalRatings) = registry.getReputationScore(targetAgent);
+
+        assertEq(score, 100); // 1 * 100
+        assertEq(totalRatings, 2);
+    }
+
+    function test_GetReputationScore_AllMaxRatings() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        vm.prank(raterB);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        (uint256 score, uint256 totalRatings) = registry.getReputationScore(targetAgent);
+
+        assertEq(score, 500); // 5 * 100
+        assertEq(totalRatings, 2);
+    }
+
+    function test_GetReputationScore_PrecisionTest() public {
+        // Test: (5 + 4) / 2 = 4.5 => 450
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        vm.prank(raterB);
+        registry.postReputation(targetAgent, 4, COMMENT_GOOD, PROOF_CID);
+
+        (uint256 score, ) = registry.getReputationScore(targetAgent);
+
+        assertEq(score, 450); // 4.5 * 100
+    }
+
+    // getRecentRatings Tests
+
+    function test_GetRecentRatings_Success() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, "First", PROOF_CID);
+
+        vm.prank(raterB);
+        registry.postReputation(targetAgent, 4, "Second", PROOF_CID);
+
+        vm.prank(raterC);
+        registry.postReputation(targetAgent, 3, "Third", PROOF_CID);
+
+        AgentReputationRegistry.Rating[] memory ratings = registry.getRecentRatings(targetAgent, 2);
+
+        assertEq(ratings.length, 2);
+        // Most recent first
+        assertEq(ratings[0].rating, 3);
+        assertEq(ratings[0].rater, raterC);
+        assertEq(ratings[1].rating, 4);
+        assertEq(ratings[1].rater, raterB);
+    }
+
+    function test_GetRecentRatings_LimitGreaterThanTotal() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        AgentReputationRegistry.Rating[] memory ratings = registry.getRecentRatings(targetAgent, 10);
+
+        assertEq(ratings.length, 1);
+        assertEq(ratings[0].rating, 5);
+    }
+
+    function test_GetRecentRatings_NoRatings() public {
+        AgentReputationRegistry.Rating[] memory ratings = registry.getRecentRatings(targetAgent, 5);
+
+        assertEq(ratings.length, 0);
+    }
+
+    function test_GetRecentRatings_RevertIfLimitZero() public {
+        vm.expectRevert(AgentReputationRegistry.InvalidLimit.selector);
+
+        registry.getRecentRatings(targetAgent, 0);
+    }
+
+    // getAllRatings Tests
+
+    function test_GetAllRatings_Success() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, "First", PROOF_CID);
+
+        vm.prank(raterB);
+        registry.postReputation(targetAgent, 4, "Second", PROOF_CID);
+
+        AgentReputationRegistry.Rating[] memory ratings = registry.getAllRatings(targetAgent);
+
+        assertEq(ratings.length, 2);
+        // Chronological order
+        assertEq(ratings[0].rating, 5);
+        assertEq(ratings[1].rating, 4);
+    }
+
+    function test_GetAllRatings_NoRatings() public {
+        AgentReputationRegistry.Rating[] memory ratings = registry.getAllRatings(targetAgent);
+
+        assertEq(ratings.length, 0);
+    }
+
+    // getRatingsCount Tests
+
+    function test_GetRatingsCount_Success() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        vm.prank(raterB);
+        registry.postReputation(targetAgent, 4, COMMENT_GOOD, PROOF_CID);
+
+        assertEq(registry.getRatingsCount(targetAgent), 2);
+    }
+
+    function test_GetRatingsCount_Zero() public {
+        assertEq(registry.getRatingsCount(targetAgent), 0);
+    }
+
+    // canRate Tests
+
+    function test_CanRate_TrueIfNeverRated() public {
+        (bool canRateNow, uint256 nextAllowedTime) = registry.canRate(raterA, targetAgent);
+
+        assertTrue(canRateNow);
+        assertEq(nextAllowedTime, 0);
+    }
+
+    function test_CanRate_FalseIfRateLimited() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        (bool canRateNow, uint256 nextAllowedTime) = registry.canRate(raterA, targetAgent);
+
+        assertFalse(canRateNow);
+        assertEq(nextAllowedTime, block.timestamp + 1 days);
+    }
+
+    function test_CanRate_TrueAfterPeriodExpires() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        vm.warp(block.timestamp + 1 days + 1);
+
+        (bool canRateNow, uint256 nextAllowedTime) = registry.canRate(raterA, targetAgent);
+
+        assertTrue(canRateNow);
+        assertEq(nextAllowedTime, 0);
+    }
+
+    function test_CanRate_IndependentForDifferentTargets() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        // Can still rate another agent
+        (bool canRateAnother, ) = registry.canRate(raterA, anotherAgent);
+        assertTrue(canRateAnother);
+
+        // Cannot rate same agent
+        (bool canRateSame, ) = registry.canRate(raterA, targetAgent);
+        assertFalse(canRateSame);
+    }
+
+    // hasBeenRated Tests
+
+    function test_HasBeenRated_True() public {
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        assertTrue(registry.hasBeenRated(targetAgent));
+    }
+
+    function test_HasBeenRated_False() public {
+        assertFalse(registry.hasBeenRated(targetAgent));
+    }
+
+    // Rating Struct Data Tests
+
+    function test_RatingData_StoredCorrectly() public {
+        uint256 ratingTime = block.timestamp;
+
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, 5, COMMENT_GOOD, PROOF_CID);
+
+        AgentReputationRegistry.Rating[] memory ratings = registry.getAllRatings(targetAgent);
+
+        assertEq(ratings[0].rating, 5);
+        assertEq(ratings[0].comment, COMMENT_GOOD);
+        assertEq(ratings[0].proofCID, PROOF_CID);
+        assertEq(ratings[0].timestamp, ratingTime);
+        assertEq(ratings[0].rater, raterA);
+    }
+
+    // Constants Tests
+
+    function test_Constants() public view {
+        assertEq(registry.MIN_RATING(), 1);
+        assertEq(registry.MAX_RATING(), 5);
+        assertEq(registry.SCORE_MULTIPLIER(), 100);
+        assertEq(registry.RATE_LIMIT_PERIOD(), 1 days);
+    }
+
+    // Fuzz Tests
+
+    function testFuzz_PostReputation_ValidRatings(uint8 rating) public {
+        vm.assume(rating >= 1 && rating <= 5);
+
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, rating, COMMENT_GOOD, PROOF_CID);
+
+        (uint256 score, uint256 totalRatings) = registry.getReputationScore(targetAgent);
+
+        assertEq(score, uint256(rating) * 100);
+        assertEq(totalRatings, 1);
+    }
+
+    function testFuzz_PostReputation_InvalidRatings(uint8 rating) public {
+        vm.assume(rating == 0 || rating > 5);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AgentReputationRegistry.InvalidRating.selector,
+                rating
+            )
+        );
+
+        vm.prank(raterA);
+        registry.postReputation(targetAgent, rating, COMMENT_GOOD, PROOF_CID);
+    }
+}


### PR DESCRIPTION
# Tasks Completed


- Created `AgentIdentityRegistry.sol` in `antiphon/contracts/`
- Implemented core functions:

```js
registerAgent(string agentCardCID)
updateAgentCard(string newCID)
getAgentCard(address agent) returns (string)
discoverAgents(string[] capabilityTags) returns (address[], string[])
```

- Add capability indexing for efficient lookup
- Implemented events: `AgentRegistered, AgentCardUpdated`
- Added access control (agents can only update their own cards)
- Wrote unit tests for both contract using foundry

- Created `AgentReputationRegistry.sol`
- Implemented core functions:

```js
postReputation(address targetAgent, uint8 rating, string comment, string proofCID)
getReputationScore(address agent) returns (uint256 score, uint256 totalRatings)
getRecentRatings(address agent, uint256 limit) returns (Rating[])
```

- Rating struct with: rating, comment, proofCID, timestamp, rater
- Implemented reputation score calculation (average * 100)
- Add spam protection (rate limiting per rater)
- Emit ReputationPosted event


# Pending task

- Replace the on-chain agents discovery with off-chain discovery to save the gas fees in on-chain discovery.
- Write the effective fuzz and invariant tests
- Update .env.example with contract addresses
- Deploy both ERC-8004 contracts to Base Sepolia testnet and verify on Basescan.

issue #1 